### PR TITLE
Use TLS to secure AccountKey header

### DIFF
--- a/main.go
+++ b/main.go
@@ -76,7 +76,7 @@ func handleIndex(w http.ResponseWriter, r *http.Request) {
 func busArrivals(id string) (arrivals SGBusArrivals, err error) {
 
 	log.Infof("Looking up %s", id)
-	url := fmt.Sprintf("http://datamall2.mytransport.sg/ltaodataservice/BusArrivalv2/?BusStopCode=%s", id)
+	url := fmt.Sprintf("https://api.mytransport.sg/ltaodataservice/BusArrivalv2/?BusStopCode=%s", id)
 
 	req, err := http.NewRequest("GET", url, nil)
 	if err != nil {


### PR DESCRIPTION
`datamall2.mytransport.sg` serves up a certificate for subject of `api.mytransport.sg`
```
$ echo | openssl s_client -showcerts -connect datamall2.mytransport.sg:443 2>/dev/null | openssl x509 -inform pem -noout -text | grep -A1 -P 'Subject( Alternative Name)?:'
        Subject: C = SG, L = Singapore, jurisdictionC = SG, O = Land Transport Authority, businessCategory = Government Entity, serialNumber = T08GB0027D, CN = api.mytransport.sg
        Subject Public Key Info:
--
            X509v3 Subject Alternative Name:
                DNS:api.mytransport.sg

```

I tried hitting the HTTPS endpoint at `api.mytransport.sg` and it seems to work so far

```
$ curl -sH "AccountKey: ${KEY}" https://api.mytransport.sg/ltaodataservice/BusArrivalv2/\?BusStopCode=07331                                                                                                                                    [0]
{"odata.metadata":"http://datamall2.mytransport.sg/ltaodataservice/$metadata#BusArrivalv2/@Element","BusStopCode":"07331","Services":[{"ServiceNo":"130","Operator":"SBST","NextBus":{"OriginCode":"03239","DestinationCode":"54009","EstimatedArrival":"2018-12-21T23:52:30+08:00","Latitude":"1.2738295","Longitude":"103.84502966666666","VisitNumber":"1","Load":"SEA","Feature":"WAB","Type":"SD"},"NextBus2":{"OriginCode":"","DestinationCode":"","EstimatedArrival":"","Latitude":"","Longitude":"","VisitNumber":"","Load":"","Feature":"","Type":""},"NextBus3":{"OriginCode":"","DestinationCode":"","EstimatedArrival":"","Latitude":"","Longitude":"","VisitNumber":"","Load":"","Feature":"","Type":""}}]}%
```