### PR TITLE
ci: add PR-triggered CI, weekly deploy schedule, bump to Go 1.27

### DIFF
--- a/.github/workflows/sam-pipeline.yml
+++ b/.github/workflows/sam-pipeline.yml
@@ -4,6 +4,12 @@ on:
   workflow_dispatch:
   push:
     branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    # An hour after the weekly bus stop update, which pushes with GITHUB_TOKEN
+    # and so cannot trigger this workflow itself.
+    - cron: '0 1 * * 0'
 
 # Cancel in-progress runs for the same branch
 concurrency:
@@ -57,6 +63,7 @@ jobs:
   deploy:
     name: Deploy
     needs: [lint, test]
+    if: github.event_name != 'pull_request'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/kaihendry/ltabus
 
-go 1.25.0
+go 1.27.0
 
 require (
 	github.com/apex/gateway/v2 v2.0.0


### PR DESCRIPTION
The pipeline only ran on push to `main`, which caused three problems:

- Dependabot PRs merged with no build or test behind them — the only check was CodeQL default setup, reporting `skipping`.
- The first post-merge run went lint → test → **deploy straight to production**, with no PR-level gate.
- `weekly-busstop-update.yml` pushes with `GITHUB_TOKEN`, and GitHub suppresses workflow runs from `GITHUB_TOKEN`-authored pushes to prevent recursion. So the weekly bus stop data was committed but never deployed: production has served `a3db121` (14 June) ever since, six data commits behind `main`.

## Changes

- **`pull_request` trigger** so lint and test gate PRs.
- **`if: github.event_name != 'pull_request'`** on the deploy job, keeping deploy a main-only action.
- **Sunday 01:00 UTC schedule**, an hour after the data update, to deploy what that push cannot trigger.
- **`go 1.25.0` → `go 1.27.0`** in `go.mod`. `setup-go` reads `go-version-file: go.mod`, so CI moves to Go 1.27 too.

## Verification

Locally on Go 1.27.0: `go build ./...`, `go vet ./...`, `go test ./...` all pass, `go mod tidy` is a no-op. This PR should also be the first to exercise its own new `pull_request` trigger — `pull_request` events evaluate the workflow from the merge commit.

## Note

Merging this will be the first `sam-pipeline` deploy in ~10 weeks and will ship the six pending bus stop data commits, bringing production from 5205 to 5208 stops.

🤖 Generated with [Claude Code](https://claude.com/claude-code)