### PR TITLE
Exclude bus stop data from the Less Hero chart

### DIFF
--- a/.github/workflows/sloc.yml
+++ b/.github/workflows/sloc.yml
@@ -33,7 +33,10 @@ jobs:
       - name: Setup Pages
         uses: actions/configure-pages@v6
       - name: Generate SLOC chart
-        uses: kaihendry/lesshero@v0.1.4
+        uses: kaihendry/lesshero@42a06280ed9dce82941da7115083b03e09acc8f1 # ignore support
+        with:
+          # Include the dataset's original path so historical counts exclude it too.
+          ignore: all.json,static/all.json
       - name: Prepare site
         run: mkdir "_site" && mv lesshero.html _site/index.html
       - name: Upload artifact


### PR DESCRIPTION
Exclude `all.json` and `static/all.json` from every historical count so bus-stop data no longer dominates the SLOC chart. Pin the action to the published commit adding `ignore` support in https://github.com/kaihendry/lesshero/pull/45.

Validation: actionlint passes. Generated both charts at main commit `78a0aaa` and independently checked all 301 first-parent commit deltas against Git numstat: the total changes from 38,653 to 2,202, removing exactly the dataset's 36,451 lines. The data and application build remain unchanged.